### PR TITLE
Implement multi-snip and configuration from source code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@imballinstack/snipsync",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@imballinstack/snipsync",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "license": "MIT",
       "dependencies": {
         "@octokit/rest": "^18.12.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@kmsi/snipsync",
+  "name": "@imballinstack/snipsync",
   "version": "1.12.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@kmsi/snipsync",
+      "name": "@imballinstack/snipsync",
       "version": "1.12.3",
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kmsi/snipsync",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kmsi/snipsync",
-      "version": "1.12.2",
+      "version": "1.12.3",
       "license": "MIT",
       "dependencies": {
         "@octokit/rest": "^18.12.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@imballinstack/snipsync",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@imballinstack/snipsync",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@octokit/rest": "^18.12.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@imballinstack/snipsync",
-  "version": "1.12.0",
+  "name": "@kmsi/snipsync",
+  "version": "1.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@imballinstack/snipsync",
-      "version": "1.12.0",
+      "name": "@kmsi/snipsync",
+      "version": "1.12.2",
       "license": "MIT",
       "dependencies": {
         "@octokit/rest": "^18.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@imballinstack/snipsync",
-  "version": "1.12.0",
+  "name": "@kmsi/snipsync",
+  "version": "1.12.2",
   "description": "Sync docs with github repo code snippets",
   "main": "index.js",
   "repository": "git@github.com:temporalio/snippetsync.git",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@kmsi/snipsync",
+  "name": "@imballinstack/snipsync",
   "version": "1.12.3",
   "description": "Sync docs with github repo code snippets",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imballinstack/snipsync",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Sync docs with github repo code snippets",
   "main": "index.js",
   "repository": "git@github.com:temporalio/snippetsync.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@imballinstack/snipsync",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Sync docs with github repo code snippets",
   "main": "index.js",
   "repository": "git@github.com:temporalio/snippetsync.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kmsi/snipsync",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "description": "Sync docs with github repo code snippets",
   "main": "index.js",
   "repository": "git@github.com:temporalio/snippetsync.git",

--- a/src/Sync.js
+++ b/src/Sync.js
@@ -63,7 +63,7 @@ class Snippet {
         });
       }
       if (config.highlights !== undefined) {
-        textline = `${textline} {${config.highlights}}`;
+        textline = `${textline} ${config.highlights}`;
       }
       lines.push(modifyWithInlineConfig(textline, config));
     }

--- a/src/Sync.js
+++ b/src/Sync.js
@@ -50,6 +50,18 @@ class Snippet {
     }
     if (config.enable_code_block) {
       let textline = fmtStartCodeBlock(this.ext);
+      if (config.override_codeblock_extension){
+        const override_extension = config.override_codeblock_extension
+        
+        override_extension.forEach(element => {
+          if (element.length !== 0 || element.length !== undefined ) {
+            const [oldExtension, replacementExtension] = element
+            if (this.ext = oldExtension) {
+              textline = fmtStartCodeBlock(replacementExtension);
+            }    
+          }
+        });
+      }
       if (config.highlights !== undefined) {
         textline = `${textline} {${config.highlights}}`;
       }
@@ -574,6 +586,11 @@ function overwriteConfig(current, extracted) {
   extracted?.enable_multi_snippet ?? true
     ? current.enable_multi_snippet
     : extracted.enable_multi_snippet;
+
+  config.override_codeblock_extension =
+  extracted?.override_codeblock_extension ?? true
+    ? current.override_codeblock_extension
+    : extracted.override_codeblock_extension;
 
   return config;
 }

--- a/src/Sync.js
+++ b/src/Sync.js
@@ -317,7 +317,12 @@ class Sync {
                   return Promise.resolve();
                 }
               }
-              fileSnips[fileSnipsCount].lines.push(line);
+              if (this.config.features.replace_tabs !== undefined) {
+                let replaced_line = line.replace(/\t/g, this.config.features.replace_tabs)
+                fileSnips[fileSnipsCount].lines.push(replaced_line);
+              } else {
+                fileSnips[fileSnipsCount].lines.push(line);
+              }
             }
             if (line.includes(readStart)) {
               capture = true;

--- a/src/Sync.js
+++ b/src/Sync.js
@@ -415,6 +415,12 @@ class Sync {
         const extracted = extractWriteIDAndConfig(line);
         if (extracted.id === snippet.id) {
           config = overwriteConfig(this.config.features, extracted.config);
+          if (this.config.features.auto_indentation) {
+            const tabsCount = hasTab(line)
+            const leadingSpace = leadinfSpaceBeforeSnipstart(line)
+            config.numberOfLeadingTabs = tabsCount
+            config.numberOfLeadingSpaces = leadingSpace  
+          }
           // check snippet config
           if (!isEmpty(snippet.config)) {
             const snippetConfig = overwriteConfig(this.config.features, snippet.config);
@@ -578,6 +584,10 @@ function overwriteConfig(current, extracted) {
     config.numberOfLeadingSpaces = extracted.numberOfLeadingSpaces;
   }
 
+  if (extracted?.numberOfLeadingTabs) {
+    config.numberOfLeadingTabs = extracted.numberOfLeadingTabs;
+  }
+
   if (extracted?.ellipsisCommentReplacement !== undefined) {
     config.ellipsisCommentReplacement = extracted.ellipsisCommentReplacement;
   }
@@ -639,6 +649,17 @@ module.exports = { Sync };
 function modifyWithInlineConfig(textLine, config) {
   let result = textLine;
 
+  if (config?.numberOfLeadingTabs) {
+    const num = config?.numberOfLeadingTabs;
+    let tabs = "";
+
+    for (let i = 0; i < num; i++) {
+      tabs += "\t";
+    }
+
+    result = `${tabs}${result}`;
+  }
+
   if (config?.numberOfLeadingSpaces) {
     const num = config?.numberOfLeadingSpaces;
     let whitespaces = "";
@@ -656,4 +677,26 @@ function modifyWithInlineConfig(textLine, config) {
 // Helper to check object
 function isEmpty(obj) {
   return Object.keys(obj).length === 0;
+}
+
+// Helper to check object
+function hasTab(line) {
+  let tabsArray = line.match(/\t/g);
+  if (tabsArray) {
+    return tabsArray.length;
+  } else {
+    return 0;
+  }
+}
+
+// Helper to check object
+function leadinfSpaceBeforeSnipstart(line) {
+  let spacesBefore = line.match(new RegExp("\\s*(?=" + writeStart + ")", "g"));
+
+  // Check if spaces are found
+  if (spacesBefore) {
+    return spacesBefore[0].length;
+  } else {
+    return 0;
+  }
 }

--- a/src/Sync.js
+++ b/src/Sync.js
@@ -415,7 +415,7 @@ class Sync {
         const extracted = extractWriteIDAndConfig(line);
         if (extracted.id === snippet.id) {
           config = overwriteConfig(this.config.features, extracted.config);
-          if (this.config.features.auto_indentation) {
+          if (this.config.features.enable_auto_indentation) {
             const tabsCount = hasTab(line)
             const leadingSpace = leadinfSpaceBeforeSnipstart(line)
             config.numberOfLeadingTabs = tabsCount

--- a/src/common.js
+++ b/src/common.js
@@ -6,6 +6,7 @@ module.exports = {
   fmtStartCodeBlock: (ext) => '```' + ext,
   readStart: '@@@SNIPSTART',
   readEnd: '@@@SNIPEND',
+  readMultiSnip: '@@@MULTISNIP',
   writeStart: '<!--SNIPSTART',
   writeStartClose: '-->',
   writeEnd: '<!--SNIPEND',

--- a/src/config.js
+++ b/src/config.js
@@ -35,5 +35,10 @@ module.exports.readConfig = (logger, file="") => {
     cfg['features']['enable_code_dedenting'] = false;
   }
 
+  // Disable code block dedenting by default if not specified
+  if (!Object.prototype.hasOwnProperty.call(cfg.features, 'enable_multi_snippet')) {
+    cfg['features']['enable_multi_snippet'] = false;
+  }
+
   return cfg;
 };

--- a/src/config.js
+++ b/src/config.js
@@ -40,10 +40,16 @@ module.exports.readConfig = (logger, file="") => {
     cfg['features']['enable_multi_snippet'] = false;
   }
 
-  // If allowed_target_extensions option isn't set, set it to an empty array
+  // If override_codeblock_extension option isn't set, set it to false
   // which will ignore the option and include all files.
   if (!Object.prototype.hasOwnProperty.call(cfg.features, 'override_codeblock_extension')) {
     cfg['features']['override_codeblock_extension'] = [];
+  }
+
+  // If auto_indentation option isn't set, set it to false
+  // which will ignore the option and include all files.
+  if (!Object.prototype.hasOwnProperty.call(cfg.features, 'auto_indentation')) {
+    cfg['features']['auto_indentation'] = false;
   }
 
   return cfg;

--- a/src/config.js
+++ b/src/config.js
@@ -46,10 +46,10 @@ module.exports.readConfig = (logger, file="") => {
     cfg['features']['override_codeblock_extension'] = [];
   }
 
-  // If auto_indentation option isn't set, set it to false
+  // If enable_auto_indentation option isn't set, set it to false
   // which will ignore the option and include all files.
-  if (!Object.prototype.hasOwnProperty.call(cfg.features, 'auto_indentation')) {
-    cfg['features']['auto_indentation'] = false;
+  if (!Object.prototype.hasOwnProperty.call(cfg.features, 'enable_auto_indentation')) {
+    cfg['features']['enable_auto_indentation'] = false;
   }
 
   return cfg;

--- a/src/config.js
+++ b/src/config.js
@@ -52,5 +52,11 @@ module.exports.readConfig = (logger, file="") => {
     cfg['features']['enable_auto_indentation'] = false;
   }
 
+  // If replace_tabs option isn't set, set it to false
+  // which will ignore the option and include all files.
+  if (!Object.prototype.hasOwnProperty.call(cfg.features, 'replace_tabs')) {
+    cfg['features']['replace_tabs'] = undefined;
+  }
+
   return cfg;
 };

--- a/src/config.js
+++ b/src/config.js
@@ -40,5 +40,11 @@ module.exports.readConfig = (logger, file="") => {
     cfg['features']['enable_multi_snippet'] = false;
   }
 
+  // If allowed_target_extensions option isn't set, set it to an empty array
+  // which will ignore the option and include all files.
+  if (!Object.prototype.hasOwnProperty.call(cfg.features, 'override_codeblock_extension')) {
+    cfg['features']['override_codeblock_extension'] = [];
+  }
+
   return cfg;
 };


### PR DESCRIPTION
I added a feature to create multi-snip and configuration directly from the source code.

We should add `@@@MULTISNIP ID` below `@@@SNIPSTART`

```
// @@@MULTISNIP ID {Optional}
```

And put `<!--SNIPSTART Unique-identifier-ID-->`

```
<!--SNIPSTART Unique-identifier-ID-->
<!--SNIPEND-->
```

example to use this feature

```h
// @@@SNIPSTART LoginWidget.h-private
// @@@MULTISNIP 2.3 {"selectedLines": ["1", "4-5"]}
// @@@MULTISNIP 2.4 {"selectedLines": ["1", "3-8"]}
// @@@MULTISNIP 2.5 {"selectedLines": ["1", "7-8"]}
// @@@MULTISNIP 3.2.1 {"selectedLines": ["1", "2-8"]}
// @@@MULTISNIP 5.2.1 {"selectedLines": ["1", "4-8"]}
private: //L1
    //add new line
	UAccelByteWarsGameInstance* GameInstance; //L3
	UAuthEssentialsSubsystem* AuthSubsystem; //L4
	UPromptSubsystem* PromptSubsystem; //L5

	UPROPERTY(BlueprintReadOnly, meta = (BindWidget, BlueprintProtected = true, AllowPrivateAccess = true)) //L7
	UWidgetSwitcher* Ws_LoginState; //L8

	UPROPERTY(BlueprintReadOnly, meta = (BindWidget, BlueprintProtected = true, AllowPrivateAccess = true)) //L10
	UCommonButtonBase* Btn_LoginWithDeviceId; //L11

	UPROPERTY(BlueprintReadOnly, meta = (BindWidget, BlueprintProtected = true, AllowPrivateAccess = true)) //L12
	UCommonButtonBase* Btn_RetryLogin; //L13

	UPROPERTY(BlueprintReadOnly, meta = (BindWidget, BlueprintProtected = true, AllowPrivateAccess = true)) //L15
	UCommonButtonBase* Btn_QuitGame; //L16

	UPROPERTY(BlueprintReadOnly, meta = (BindWidget, BlueprintProtected = true, AllowPrivateAccess = true)) //L18
	UTextBlock* Tb_FailedMessage; //L19
	
	UPROPERTY(EditDefaultsOnly) //L21
	TSubclassOf<UAccelByteWarsActivatableWidget> MainMenuWidgetClass; //L22
// @@@SNIPEND
```

```h
<!--SNIPSTART LoginWidget.h-private-->
private: //L1
    //add new line
	UAccelByteWarsGameInstance* GameInstance; //L3
	UAuthEssentialsSubsystem* AuthSubsystem; //L4
	UPromptSubsystem* PromptSubsystem; //L5

	UPROPERTY(BlueprintReadOnly, meta = (BindWidget, BlueprintProtected = true, AllowPrivateAccess = true)) //L7
	UWidgetSwitcher* Ws_LoginState; //L8

	UPROPERTY(BlueprintReadOnly, meta = (BindWidget, BlueprintProtected = true, AllowPrivateAccess = true)) //L10
	UCommonButtonBase* Btn_LoginWithDeviceId; //L11

	UPROPERTY(BlueprintReadOnly, meta = (BindWidget, BlueprintProtected = true, AllowPrivateAccess = true)) //L12
	UCommonButtonBase* Btn_RetryLogin; //L13

	UPROPERTY(BlueprintReadOnly, meta = (BindWidget, BlueprintProtected = true, AllowPrivateAccess = true)) //L15
	UCommonButtonBase* Btn_QuitGame; //L16

	UPROPERTY(BlueprintReadOnly, meta = (BindWidget, BlueprintProtected = true, AllowPrivateAccess = true)) //L18
	UTextBlock* Tb_FailedMessage; //L19
	
	UPROPERTY(EditDefaultsOnly) //L21
	TSubclassOf<UAccelByteWarsActivatableWidget> MainMenuWidgetClass; //L22
<!--SNIPEND-->

<!--SNIPSTART LoginWidget.h-private {"selectedLines": ["1", "2-3"]}-->
private: //L1
// ...
    //add new line
	UAccelByteWarsGameInstance* GameInstance; //L3
<!--SNIPEND-->

<!--SNIPSTART LoginWidget.h-private-2.3-->
private: //L1
// ...
	UAuthEssentialsSubsystem* AuthSubsystem; //L4
	UPromptSubsystem* PromptSubsystem; //L5
<!--SNIPEND-->

<!--SNIPSTART LoginWidget.h-private-2.4-->
private: //L1
// ...
	UAccelByteWarsGameInstance* GameInstance; //L3
	UAuthEssentialsSubsystem* AuthSubsystem; //L4
	UPromptSubsystem* PromptSubsystem; //L5

	UPROPERTY(BlueprintReadOnly, meta = (BindWidget, BlueprintProtected = true, AllowPrivateAccess = true)) //L7
	UWidgetSwitcher* Ws_LoginState; //L8
<!--SNIPEND-->

<!--SNIPSTART LoginWidget.h-private-2.5-->
private: //L1
// ...
	UPROPERTY(BlueprintReadOnly, meta = (BindWidget, BlueprintProtected = true, AllowPrivateAccess = true)) //L7
	UWidgetSwitcher* Ws_LoginState; //L8
<!--SNIPEND-->
```

````yml
origins:
  - files:
      - ./test/multisnip/*.h

targets:
  - test/multisnip
  - blog

features:
  enable_source_link: false
  enable_code_block: false
  allowed_target_extensions: [.md]
  enable_code_dedenting: false
  enable_multi_snippet: true #Set to true
````